### PR TITLE
boot-yarn

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -15,18 +15,27 @@
                  [hiccup "1.0.5"]
 
                  [org.clojure/test.check "0.9.0" :scope "test"]
+                 [com.cemerick/piggieback "0.2.1" :scope "test"]
+                 [weasel "0.7.0" :scope "test"]
+                 [org.clojure/tools.nrepl "0.2.12" :scope "test"]
+
+                 [degree9/boot-exec "0.4.0" :scope "test"]
                  [samestep/boot-refresh "0.1.0" :scope "test"]
                  [adzerk/boot-reload "0.4.13" :scope "test"]
                  [adzerk/boot-cljs "1.7.228-2" :scope "test"]
-                 [adzerk/boot-cljs-repl "0.3.3" :scope "test"]
-                 [com.cemerick/piggieback "0.2.1" :scope "test"]
-                 [weasel "0.7.0" :scope "test"]
-                 [org.clojure/tools.nrepl "0.2.12" :scope "test"]])
+                 [adzerk/boot-cljs-repl "0.3.3" :scope "test"]])
+
 
 (require '[samestep.boot-refresh :refer [refresh]])
 (require '[adzerk.boot-reload :refer [reload]])
 (require '[adzerk.boot-cljs :refer [cljs]])
 (require '[adzerk.boot-cljs-repl :refer [cljs-repl-env start-repl]])
+(require '[degree9.boot-exec :refer [exec]])
+
+(deftask yarn [a arguments VAL [str]]
+  (exec :process "yarn"
+        :arguments arguments
+        :directory "."))
 
 (deftask cider []
   (require 'boot.repl)
@@ -39,6 +48,8 @@
   (merge-env! :source-paths #{"src/clj-dev"})
   (require ['user :as 'u])
   (comp
+   (yarn)
+   (yarn :arguments ["build-watch"])
    (repl :server true)
    (watch)
    (refresh)


### PR DESCRIPTION
Надо подумать, как удобно запускать сборку вместе с стартом repl. Так же важны сообщения об ошибках в webpack, сейчас они не показываются. 